### PR TITLE
Feature/Caterings by location

### DIFF
--- a/banquetBuddy/catering_particular/templates/listar_caterings.html
+++ b/banquetBuddy/catering_particular/templates/listar_caterings.html
@@ -123,6 +123,34 @@
       </div>
     </div>
 
+    <!-- Filtro por número de invitados -->
+    <div class="form-group">
+      <label for="ciudad">Location:</label>
+      <div class="input-group">
+        <input
+          type="text"
+          class="form-control"
+          id="ciudad"
+          name="ciudad"
+          placeholder="City or Postcode"
+          value="{{ ciudad }}"
+        />
+        <!-- Botón para eliminar filtro -->
+        {% if ciudad %}
+        <div class="input-group-append">
+          <button
+            type="submit"
+            name="limpiar_ciudad"
+            value="1"
+            class="btn btn-sm btn-danger"
+          >
+            <i class="fa fa-times"></i>
+          </button>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+
     <!-- Botón para aplicar filtros -->
     <div class="d-flex justify-content-center">
       <button type="submit" class="btn btn-primary">Filter</button>

--- a/banquetBuddy/catering_particular/tests.py
+++ b/banquetBuddy/catering_particular/tests.py
@@ -73,87 +73,116 @@ class CateringViewsTestCase(TestCase):
         # Verificar que la respuesta contiene el nombre del servicio de catering
         self.assertContains(response, self.catering_service.name)
 
+
 class BookingProcessTestCase(TestCase):
     def setUp(self):
-        self.user = CustomUser.objects.create_user(username='testuser', email='test@example.com', password='testpassword')
-        self.user1 = CustomUser.objects.create_user(username='testuser2', email='test2@example.com', password='testpassword2')
+        self.user = CustomUser.objects.create_user(
+            username="testuser", email="test@example.com", password="testpassword"
+        )
+        self.user1 = CustomUser.objects.create_user(
+            username="testuser2", email="test2@example.com", password="testpassword2"
+        )
 
         self.company = CateringCompany.objects.create(
             user=self.user,
-            name='Test Catering Company',
-            phone_number='123456789',
-            service_description='Test service description',
-            price_plan='BASE'
+            name="Test Catering Company",
+            phone_number="123456789",
+            service_description="Test service description",
+            price_plan="BASE",
         )
 
         self.particular = Particular.objects.create(
             user=self.user1,
-            phone_number='123456789',
-            preferences='Test preferences',
-            address='Test address',
-            is_subscribed=False
+            phone_number="123456789",
+            preferences="Test preferences",
+            address="Test address",
+            is_subscribed=False,
         )
 
         self.catering_service = CateringService.objects.create(
             cateringcompany=self.company,
-            name='Test Catering Service',
-            description='Test service description',
-            location='Test location',
+            name="Test Catering Service",
+            description="Test service description",
+            location="Test location",
             capacity=100,
-            price=100.00
+            price=100.00,
         )
 
         self.menu = Menu.objects.create(
-            id = 1,
+            id=1,
             cateringservice=self.catering_service,
-            name='Test Menu',
-            description='Test menu description',
-            diet_restrictions='Test diet restrictions'
+            name="Test Menu",
+            description="Test menu description",
+            diet_restrictions="Test diet restrictions",
         )
         self.catering_service.menus.add(self.menu)
 
-    
         self.client = Client()
 
     def test_booking_process(self):
-        self.client.login(username='testuser2', password='testpassword2')
+        self.client.login(username="testuser2", password="testpassword2")
         catering_id = self.catering_service.id
-        url = reverse('booking_process', kwargs={'catering_id': catering_id})
+        url = reverse("booking_process", kwargs={"catering_id": catering_id})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        response = self.client.post(url, {'event_date': '2026-03-11', 'number_guests': '50', 'selected_menu': '1'})
+        response = self.client.post(
+            url,
+            {"event_date": "2026-03-11", "number_guests": "50", "selected_menu": "1"},
+        )
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(Event.objects.filter(cateringservice=self.catering_service, date='2026-03-11', number_guests=50).exists())
+        self.assertTrue(
+            Event.objects.filter(
+                cateringservice=self.catering_service,
+                date="2026-03-11",
+                number_guests=50,
+            ).exists()
+        )
 
     def test_invalid_booking_process(self):
-        self.client.login(username='testuser2', password='testpassword2')
+        self.client.login(username="testuser2", password="testpassword2")
         catering_id = self.catering_service.id
-        url = reverse('booking_process', kwargs={'catering_id': catering_id})
+        url = reverse("booking_process", kwargs={"catering_id": catering_id})
 
-        response = self.client.post(url, {'event_date': '2024-03-11', 'number_guests': '1000', 'menu_selected': '1'})
+        response = self.client.post(
+            url,
+            {"event_date": "2024-03-11", "number_guests": "1000", "menu_selected": "1"},
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(Event.objects.filter(cateringservice=self.catering_service).exists())
+        self.assertFalse(
+            Event.objects.filter(cateringservice=self.catering_service).exists()
+        )
 
-        response = self.client.post(url, {'event_date': '2024-03-11', 'number_guests': '10', 'menu_selected': ''})
+        response = self.client.post(
+            url,
+            {"event_date": "2024-03-11", "number_guests": "10", "menu_selected": ""},
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(Event.objects.filter(cateringservice=self.catering_service).exists())
+        self.assertFalse(
+            Event.objects.filter(cateringservice=self.catering_service).exists()
+        )
 
-        response = self.client.post(url, {'event_date': '2020-03-11', 'number_guests': '10', 'menu_selected': ''})
+        response = self.client.post(
+            url,
+            {"event_date": "2020-03-11", "number_guests": "10", "menu_selected": ""},
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(Event.objects.filter(cateringservice=self.catering_service).exists())
+        self.assertFalse(
+            Event.objects.filter(cateringservice=self.catering_service).exists()
+        )
 
     def test_unauthorized_access(self):
         catering_id = self.catering_service.id
-        url = reverse('booking_process', kwargs={'catering_id': catering_id})
+        url = reverse("booking_process", kwargs={"catering_id": catering_id})
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
-        self.assertIn('/accounts/login/', response.url)
+        self.assertIn("/accounts/login/", response.url)
 
-        self.client.login(username='testuser', password='testpassword')
+        self.client.login(username="testuser", password="testpassword")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+
 
 class FiltrosTest(TestCase):
     def setUp(self):
@@ -205,3 +234,27 @@ class FiltrosTest(TestCase):
         self.assertEqual(response.status_code, 200)
         # Asegúrate de que no hay filtros de cocina en la respuesta
         self.assertFalse(response.context["cocina"])
+
+    def test_filtrado_por_ciudad(self):
+        response = self.client.get(reverse("listar_caterings") + "?ciudad=Huesca")
+        self.assertEqual(response.status_code, 200)
+        # Asegúrate de que solo los caterings de la ciudad de Huesca están en la respuesta
+        caterings = response.context["caterings"]
+        for catering in caterings:
+            self.assertTrue("Huesca" in catering.location)
+
+    def test_filtrado_por_ciudad(self):
+        response = self.client.get(reverse("listar_caterings") + "?ciudad=27789")
+        self.assertEqual(response.status_code, 200)
+        # Asegúrate de que solo los caterings con CP 27789 están en la respuesta
+        caterings = response.context["caterings"]
+        for catering in caterings:
+            self.assertTrue("27789" in catering.location)
+
+    def test_limpiar_filtro_ciudad(self):
+        response = self.client.get(
+            reverse("listar_caterings") + "?ciudad=Huesca&limpiar_ciudad=1"
+        )
+        self.assertEqual(response.status_code, 200)
+        # Asegúrate de que no hay filtros de ciudad en la respuesta
+        self.assertFalse(response.context["ciudad"])

--- a/banquetBuddy/catering_particular/views.py
+++ b/banquetBuddy/catering_particular/views.py
@@ -1,4 +1,5 @@
-from django.shortcuts import render, get_object_or_404, HttpResponse,redirect
+import re
+from django.shortcuts import render, get_object_or_404, HttpResponse, redirect
 from django.contrib import messages
 from catering_owners.models import CateringService
 from .forms import ParticularForm
@@ -45,12 +46,14 @@ def obtener_filtros(request):
         "cocina": request.GET.get("cocina", ""),
         "precio_maximo": request.GET.get("precio_maximo", ""),
         "num_invitados": request.GET.get("num_invitados", ""),
+        "ciudad": request.GET.get("ciudad", ""),
     }
 
     limpiar_filtros = {
         "limpiar_cocina": request.GET.get("limpiar_cocina", None),
         "limpiar_precio": request.GET.get("limpiar_precio", None),
         "limpiar_invitados": request.GET.get("limpiar_invitados", None),
+        "limpiar_ciudad": request.GET.get("limpiar_ciudad", None),
     }
 
     return filtros, limpiar_filtros
@@ -87,6 +90,10 @@ def aplicar_filtros(caterings, filtros, limpiar_filtros):
         caterings = caterings.filter(capacity__gte=filtros["num_invitados"])
     else:
         filtros["num_invitados"] = ""
+    if filtros["ciudad"] and not limpiar_filtros["limpiar_ciudad"]:
+        caterings = caterings.filter(Q(location__icontains=filtros["ciudad"]))
+    else:
+        filtros["ciudad"] = ""
 
     return caterings, filtros
 
@@ -99,6 +106,9 @@ def listar_caterings(request):
     if not is_particular(request):
         return HttpResponseForbidden("You are not a particular")
     caterings = CateringService.objects.all()
+
+    for catering in caterings:
+        print(catering.location)
 
     # Obtener tipos de cocina únicos
     tipos_cocina = (
@@ -138,89 +148,106 @@ def catering_detail(request, catering_id):
     context["is_catering_company"] = is_catering_company(request)
     if not is_particular(request):
         return HttpResponseForbidden("No eres cliente")
-    catering = get_object_or_404(CateringService, id = catering_id)
-    context['catering'] = catering
-    return render(request, 'catering_detail.html', context)
+    catering = get_object_or_404(CateringService, id=catering_id)
+    context["catering"] = catering
+    return render(request, "catering_detail.html", context)
 
 
 @login_required
 def booking_process(request, catering_id):
     cateringservice = get_object_or_404(CateringService, id=catering_id)
-    print(cateringservice.cateringcompany_id) 
-    catering = get_object_or_404(CateringCompany, user_id = cateringservice.cateringcompany_id)
+    print(cateringservice.cateringcompany_id)
+    catering = get_object_or_404(
+        CateringCompany, user_id=cateringservice.cateringcompany_id
+    )
     user = request.user
     particular = get_object_or_404(Particular, user_id=user.id)
 
-    eventos = Event.objects.filter(cateringservice_id = catering.user_id)
+    eventos = Event.objects.filter(cateringservice_id=catering.user_id)
     highlighted_dates = []
-    
+
     for evento in eventos:
         highlighted_dates.append(evento.date)
     # Obtener el menú para el catering actual
-    highlighted_dates_str = [date.strftime('%Y-%m-%d') for date in highlighted_dates]
-
-    
+    highlighted_dates_str = [date.strftime("%Y-%m-%d") for date in highlighted_dates]
 
     menus = Menu.objects.filter(cateringcompany_id=catering.user_id)
-    
+
     # Coloca el menú dentro del contexto correctamente
-    context = {'cateringservice': cateringservice,'catering': catering, 'menus': menus,'dates' : highlighted_dates_str}
-    if request.method == 'POST':
-        event_date = request.POST.get('event_date')
-        number_guests = request.POST.get('number_guests')
-        selected_menu = request.POST.get('selected_menu')
+    context = {
+        "cateringservice": cateringservice,
+        "catering": catering,
+        "menus": menus,
+        "dates": highlighted_dates_str,
+    }
+    if request.method == "POST":
+        event_date = request.POST.get("event_date")
+        number_guests = request.POST.get("number_guests")
+        selected_menu = request.POST.get("selected_menu")
 
         print(selected_menu)
         # Validación y lógica de reserva aquí
         if not selected_menu:
-            messages.error(request, 'Please select a menu')
-            context['form_error_menu'] = True
-             
+            messages.error(request, "Please select a menu")
+            context["form_error_menu"] = True
+
         if not (event_date and number_guests and selected_menu):
-            messages.error(request, 'Please complete all fields')
-            context['form_error'] = True  # Agregar marcador para mostrar mensajes de error
+            messages.error(request, "Please complete all fields")
+            context["form_error"] = (
+                True  # Agregar marcador para mostrar mensajes de error
+            )
 
         if int(number_guests) > cateringservice.capacity:
-            messages.error(request, 'Number of guests exceeds the catering capacity')
-            context['form_error_capacity'] = True
+            messages.error(request, "Number of guests exceeds the catering capacity")
+            context["form_error_capacity"] = True
 
         # Validar que la fecha no esté en el pasado y sea al menos un día en el futuro
         today = datetime.now().date()
-        selected_date = datetime.strptime(event_date, '%Y-%m-%d').date()
+        selected_date = datetime.strptime(event_date, "%Y-%m-%d").date()
 
         if selected_date < today:
-            messages.error(request, 'The event date cannot be in the past')
-            context['form_error_date'] = True
+            messages.error(request, "The event date cannot be in the past")
+            context["form_error_date"] = True
         elif selected_date == today:
-            messages.error(request, 'Reservations must be made at least one day before the event')
-            context['form_error_date'] = True
+            messages.error(
+                request, "Reservations must be made at least one day before the event"
+            )
+            context["form_error_date"] = True
 
-        if Event.objects.filter(cateringservice=cateringservice, date=event_date).exists():
-            messages.error(request, 'The selected date is already booked')
-            context['form_error_date_selected'] = True
+        if Event.objects.filter(
+            cateringservice=cateringservice, date=event_date
+        ).exists():
+            messages.error(request, "The selected date is already booked")
+            context["form_error_date_selected"] = True
 
         # Verificar si hay errores en el formulario y, si los hay, volver a renderizar la página con los errores
-        if any(key in context for key in ['form_error', 'form_error_capacity', 'form_error_date','form_error_date_selected']):
-            return render(request, 'booking_process.html', context)
+        if any(
+            key in context
+            for key in [
+                "form_error",
+                "form_error_capacity",
+                "form_error_date",
+                "form_error_date_selected",
+            ]
+        ):
+            return render(request, "booking_process.html", context)
 
-        menu = Menu.objects.get(id = selected_menu)
+        menu = Menu.objects.get(id=selected_menu)
         # Crear el evento y hacer la reserva
         event = Event.objects.create(
             cateringservice=cateringservice,
             particular=particular,
-            name=f'Reservation for {catering.name} by {user.username}',
+            name=f"Reservation for {catering.name} by {user.username}",
             date=event_date,
-            details=f'Reservation for {number_guests} guests',
-            menu = menu,
+            details=f"Reservation for {number_guests} guests",
+            menu=menu,
             booking_state=BookingState.CONTRACT_PENDING,
-            number_guests=number_guests
+            number_guests=number_guests,
         )
 
         # Puedes agregar más lógica según sea necesario
 
-        return redirect('/')
+        return redirect("/")
 
     # Si no es una solicitud POST, renderizar la página con el formulario
-    return render(request, 'booking_process.html', context)
-
-
+    return render(request, "booking_process.html", context)


### PR DESCRIPTION
## R-025: Catering por localización #91

### Descripción

Se ha añadido una opción en los filtros del listado de caterings, que permite a los particulares filtrar por localización, introduciendo el nombre de una ciudad o el código postal.

### Contexto Adicional
Pasos para la revisión:

1. El revisor debe loguearse como particular
2. Acceder a localhost:8080/caterings/ 
3. Comprobar que se puede filtrar los caterings poniendo una ciudad o un código postal. (por ejemplo, Huesca o 27789)

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] Se ha probado que la aplicación se levanta en local.
- [x] Se ha probado que los cambios se integran bien en la aplicación.
- [x] Se ha probado que los cambios corresponden con los solicitados en la tarea.

Closes #91 
