### PR TITLE
Feature/setup sonarcloud#148

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x' # Set this to your Python version
+        python-version: '3.x' 
     - name: Install dependencies
       run: pip install -r requirements.txt
     - name: SonarCloud Scan

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,20 @@
+name: SonarCloud
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x' # Set this to your Python version
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarcloud-github-action@master
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.projectKey=ISPP-GRUPO-8_BANQUETBUDDY
+sonar.organization=ispp-grupo-8
+sonar.sources=.
+sonar.python.version=3.x  


### PR DESCRIPTION
Configuración de SonarCloud #148 

### Descripción

Este Pull Request establece la integración de SonarCloud con nuestro código, **utilizando GitHub Actions** para automatizar el análisis de código en nuestros **push** y **pull requests**.  El análisis automático de SonarCloud **ha sido deshabilitado** en la propia configuración de SonarCloud para que GitHub Actions maneje este proceso y así evitar superposiciones entre los análisis que provocan conflictos. De esta manera, veremos el informe de SonarCloud directamente en GitHub, pero igualmente podemos acceder a él en [sonarcloud.io](url)



### Contexto Adicional

- Los miembros del equipo al iniciar sesión en SonarCloud, **con la misma cuenta que tienen asociada en GitHub**, deberían poder ver automáticamente el repositorio ya asociado a la organización de SonarCloud (solo el repositorio BANQUETBUDDY, no los de landing page y docosaurus). Está en **"My Organizations"** dentro de tu perfil de SonarCloud.
- No hace falta configurar nada en SonarCloud ya que esa configuración se aplica a nivel de proyecto y está disponible para todos los miembros de la organización en SonarCloud gracias a la importación de la organización [ISPP-GRUPO-8](https://github.com/ISPP-GRUPO-8) desde el GitHub.
 - A la hora de crear la pull request, no todos los miembros aparecían en SonarCloud, informandome la propia herramienta de que _"You might not see all members from your GitHub organization yet, as they need to connect to SonarCloud at least once to appear in this list."_ por eso es importante iniciar la sesión en SonarCloud con la misma cuenta que estás utilizando en GitHub para BanquetBuddy


## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [ ] Se ha probado que la aplicación se levanta en local.
- [ ] Se ha probado que los cambios se integran bien en la aplicación.
- [ ] Se ha probado que los cambios corresponden con los solicitados en la tarea.
Don't forget close #148 
