### PR TITLE
fix: SonarCloud coverage improved

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -52,13 +52,4 @@ jobs:
         run: |
           cd banquetBuddy
           coverage run --source='.' manage.py test
-          coverage xml -o coverage-reports/coverage.xml
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: >
-            -Dsonar.python.coverage.reportPaths=banquetBuddy/coverage-reports/coverage.xml
+          coverage xml -o ../coverage-reports/coverage.xml --omit '*/tests/*'

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -52,4 +52,13 @@ jobs:
         run: |
           cd banquetBuddy
           coverage run --source='.' manage.py test
-          coverage xml
+          coverage xml -o coverage-reports/coverage.xml
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.python.coverage.reportPaths=banquetBuddy/coverage-reports/coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@ sonar.projectKey=ISPP-GRUPO-8_BANQUETBUDDY
 sonar.organization=ispp-grupo-8
 sonar.sources=.
 sonar.python.version=3.x
-sonar.python.coverage.reportPaths=banquetBuddy/coverage.xml
+sonar.python.coverage.reportPaths=banquetBuddy/coverage-reports/coverage.xml


### PR DESCRIPTION
Configuración de Cobertura de Código #178 
Descripción
Se han realizado ajustes en los flujos de trabajo de GitHub Actions para generar informes de cobertura de código y vincularlos con SonarCloud.

Contexto Adicional
Si bien la herramienta coverage estaba ya puesta en requierements.txt previamente, asegurate de tenerla instalada, ya que el requierements se va actualizando por los compañeros de cuando en cuando. Haz pip install -r requirements.txt

SonarQube utilizará archivo coverage.xml para obtener los datos de cobertura. Este archivo se crea por GitHub Actions con la nueva configuración a la hora de hacer push/pull request.

Puedes generar el archivo coverage.xml en local (pero no es necesario para la revisión, simplemente un dato a saber):

1) cd banquetBuddy
2) coverage run --source='.' manage.py test
3) coverage xml

Ten en cuenta que coverage.xml está excluido por gitignore que tenemos en el proyecto y no hace falta cambiar esta opción.
## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [ ] Se ha probado que la aplicación se levanta en local.
- [ ] Se ha probado que los cambios se integran bien en la aplicación.
- [ ] Se ha probado que los cambios corresponden con los solicitados en la tarea.
Close #178 