### PR TITLE
feat:  añadido boton manual para limpiar notificaciones #200

### DIFF
--- a/banquetBuddy/catering_employees/signals.py
+++ b/banquetBuddy/catering_employees/signals.py
@@ -7,7 +7,6 @@ from catering_owners.models import JobApplication, NotificationJobApplication
 def notify_employee_on_state_change(sender, instance, **kwargs):
     
     employee = instance.employee.user
-    NotificationJobApplication.objects.filter(user=employee, has_been_read=True).delete()
     if instance.state == 'PENDING':
         message = f"Tu aplicación a la oferta {instance.offer.title}, se ha enviado correctamente."
     else:

--- a/banquetBuddy/catering_owners/models.py
+++ b/banquetBuddy/catering_owners/models.py
@@ -168,13 +168,11 @@ class NotificationEvent(models.Model):
     user = models.ForeignKey(CustomUser, on_delete=models.CASCADE, related_name='user')
     event = models.ForeignKey(Event, on_delete=models.CASCADE, related_name='event')
     message = models.TextField()
-    has_been_read = models.BooleanField(default=False)
     
 class NotificationJobApplication(models.Model):
     user = models.ForeignKey(CustomUser, on_delete=models.CASCADE, related_name='employee_receiver')
     job_application = models.ForeignKey(JobApplication, on_delete=models.CASCADE, related_name='job_application')
     message = models.TextField()
-    has_been_read = models.BooleanField(default=False)
 
 class RecommendationLetter(models.Model): 
     employee = models.ForeignKey(Employee, on_delete=models.CASCADE, related_name='employee')

--- a/banquetBuddy/core/templates/core/notifications.html
+++ b/banquetBuddy/core/templates/core/notifications.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 {% extends 'core/base.html' %}
+{% block extra_css %}
 {% load static %}
-
+<link rel="stylesheet" type="text/css" href="{% static 'styles.css' %}">
+{% endblock %}
 {% block content %}
 <style>
     h1 {
@@ -41,7 +43,10 @@
 </style>
     <h1 style="margin-top: 2%;">Notifications</h1>
     <div class="list">
-            
+        <form method="post" action="{% url 'mark_as_read' %}">
+            {% csrf_token %}
+            <button class="btn btn-primary btn-add my-2 my-sm-0" type="submit">Mark as read</button>
+        </form>
         {% for notification in notifications %}
         <div class="notification">
         {% if request.user.is_authenticated and request.user.EmployeeUsername %}

--- a/banquetBuddy/core/tests.py
+++ b/banquetBuddy/core/tests.py
@@ -361,7 +361,7 @@ class NotificationViewTest(TestCase):
             booking_state = BookingState.CONTRACT_PENDING,
             number_guests = 23
         )
-        self.notification1 = NotificationEvent.objects.create(user=self.user1, has_been_read=False, message='Test notification 1', event=self.event)
+        self.notification1 = NotificationEvent.objects.create(user=self.user1, message='Test notification 1', event=self.event)
     
     def test_notification_view(self):
         # Simula una solicitud GET al view
@@ -373,10 +373,6 @@ class NotificationViewTest(TestCase):
         
         # Verifica que se haya llamado a la plantilla correcta
         self.assertEqual(response.status_code, 200)
-        
-        # Verifica que las notificaciones no leídas se hayan marcado como leídas
-        self.notification1.refresh_from_db()
-        self.assertTrue(self.notification1.has_been_read)
 
 
     

--- a/banquetBuddy/core/urls.py
+++ b/banquetBuddy/core/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('terms-archive/', terms_archive, name='terms_archive'),
     path('privacy-policy/v1.0/', policy_version1_0, name='policy_version1_0'),
     path('terms-and-conditions/v1.0/', terms_version1_0, name='terms_version1_0'),
+    path('mark-as-read/', mark_notifications_as_read, name='mark_as_read'),
 
 
 

--- a/banquetBuddy/core/views.py
+++ b/banquetBuddy/core/views.py
@@ -66,7 +66,7 @@ def home(request):
     random_caterings = sample(list(caterings), 4)
     
     if request.user.is_authenticated:
-        notifications = NotificationEvent.objects.filter(user=request.user, has_been_read=False).count() + NotificationJobApplication.objects.filter(user=request.user, has_been_read=False).count()
+        notifications = NotificationEvent.objects.filter(user=request.user).count() + NotificationJobApplication.objects.filter(user=request.user).count()
         context['notification_number'] = notifications
     
     context['offers'] = random_offers
@@ -451,15 +451,9 @@ def notification_view(request):
     current_user = request.user
     try:
         employee = Employee.objects.get(user=current_user)
-        notifications = NotificationJobApplication.objects.filter(user=current_user, has_been_read=False)
-        for notification in notifications:
-            notification.has_been_read = True
-            notification.save()
+        notifications = NotificationJobApplication.objects.filter(user=current_user)
     except Employee.DoesNotExist:
-        notifications = NotificationEvent.objects.filter(user=current_user, has_been_read=False)
-        for notification in notifications:
-            notification.has_been_read = True
-            notification.save()
+        notifications = NotificationEvent.objects.filter(user=current_user)
     context = {'notifications' : notifications}
         
     return render(request, 'core/notifications.html', context)
@@ -468,7 +462,6 @@ def notification_view(request):
 
 def send_notifications_next_events_particular(request):
     current_user = request.user
-    NotificationEvent.objects.filter(user=current_user, has_been_read=True).delete()
     week_after = timezone.now() + timedelta(days=7)
     next_events = Event.objects.filter(date__lte=week_after, particular__user=current_user)
     
@@ -482,7 +475,6 @@ def send_notifications_next_events_particular(request):
             
 def send_notifications_next_events_catering_company(request):
     current_user = request.user
-    NotificationEvent.objects.filter(user=current_user, has_been_read=True).delete()
     week_after = timezone.now() + timedelta(days=7)
     catering_company = get_object_or_404(CateringCompany, user=current_user)
     next_events = Event.objects.filter(date__lte=week_after, cateringservice__cateringcompany=catering_company)
@@ -519,6 +511,21 @@ def policy_version1_0(request):
 
 def terms_version1_0(request):
     return render(request, 'core/politicas y terminos anteriores/termsv1.0.html')
+
+#Borrado de notificaciones
+def mark_notifications_as_read(request):
+    current_user = request.user
+    try:
+        employee = Employee.objects.get(user=current_user)
+        notifications = NotificationJobApplication.objects.filter(user=current_user)
+    except Employee.DoesNotExist:
+        notifications = NotificationEvent.objects.filter(user=current_user)
+        
+    for notification in notifications:
+            notification.delete()
+            
+    return redirect('notifications')
+    
 
 
 


### PR DESCRIPTION
## añadir boton manual para limpiar notificaciones (pilot users feedback)#200 

### Descripción

Se ha añadido un botón para marcar las notificaciones como leido de forma manual, las notificaciones no se deben quitar al recargar la página si no se han marcado como leido.

### Contexto Adicional

Crear notificaciones, se puede hacer de diferentes formas, por ejemplo creando como particular un evento que ocurra en menos de una semana y deslogearse y volver a logearse, ir a la pestaña de notificaciones y ver que aparece, probar a recargar la pagina para ver que no desaparece, darle al botón de mark as read y comprobar que no vuelven a aparecer dichas notificaciones.

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] Se ha probado que la aplicación se levanta en local.
- [x] Se ha probado que los cambios se integran bien en la aplicación.
- [x] Se ha probado que los cambios corresponden con los solicitados en la tarea.
Closes #200 