### PR TITLE
Corrección de visualización de platos en menús

### DIFF
--- a/banquetBuddy/catering_particular/templates/booking_process.html
+++ b/banquetBuddy/catering_particular/templates/booking_process.html
@@ -58,21 +58,30 @@
         <label for="menu">Select Menu:</label>
         <div class="row">
           {% for menu in menus %}
-          <div class="col-md-4 mb-4">
-            <div class="card h-100 d-flex flex-column shadow-sm custom-card-bg">
-              <div class="card-body flex-fill d-flex flex-column">
+    <div class="col-md-4 mb-4">
+        <div class="card h-100 d-flex flex-column shadow-sm custom-card-bg">
+            <div class="card-body flex-fill d-flex flex-column">
                 <h4 class="card-title">{{ menu.name }}</h4>
                 <p class="card-text">{{ menu.description }}</p>
+                <h5 class="card-subtitle mb-2 text-muted">Plates:</h5>
+                <ul>
+                    {% for plate in menus_with_plates.items %}
+                        {% if plate.0 == menu %}
+                            {% for p in plate.1 %}
+                                <li>{{ p.name }}: <span class="text-muted">{{ p.description }}</span></li>
+                            {% endfor %}
+                        {% endif %}
+                    {% endfor %}
+                </ul>
                 <div class="mt-auto">
-                  <div class="btn-group">
-                    <button type="button" class="btn btn-add select-menu"
-                      data-menu-id="{{ menu.id }}">Select</button>
-                  </div>
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-add select-menu" data-menu-id="{{ menu.id }}">Select</button>
+                    </div>
                 </div>
-              </div>
             </div>
-          </div>
-          {% endfor %}
+        </div>
+    </div>
+{% endfor %}
           <input type="hidden" name="selected_menu" id="selected_menu">
         </div>
         </br>

--- a/banquetBuddy/catering_particular/views.py
+++ b/banquetBuddy/catering_particular/views.py
@@ -383,13 +383,20 @@ def booking_process(request, catering_id):
 
     menus = Menu.objects.filter(cateringservice=cateringservice.id)
 
+    menus_plates = {}
+    for m in menus:
+        plates = Plate.objects.filter(menu=m)
+        menus_plates[m] = plates        
+
     # Coloca el menú dentro del contexto correctamente
     context = {
         "cateringservice": cateringservice,
         "catering": catering,
         "menus": menus,
+        "menus_with_plates": menus_plates,
         "dates": highlighted_dates_str,
     }
+
     if request.method == "POST":
         event_date = request.POST.get("event_date")
         request.session["event_date"] = event_date


### PR DESCRIPTION
## Corrección de visualización de platos en menús #267

### Descripción

Introduce la visualización de los platos correspondientes a un menu, en la vista de reserva de servicios. Los usuarios podrán ahora ver los platos del menú que escojan.

### Contexto Adicional

Para comprobar la funcionalidad, navegar a la pantalla de reserva de servicios.

## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] Se ha probado que la aplicación se levanta en local.
- [x] Se ha probado que los cambios se integran bien en la aplicación.
- [x] Se ha probado que los cambios corresponden con los solicitados en la tarea.
