### PR TITLE
fix: Arreglar editar reserva

### DIFF
--- a/banquetBuddy/catering_particular/views.py
+++ b/banquetBuddy/catering_particular/views.py
@@ -55,6 +55,8 @@ def book_cancel(request, event_id):
     events = Event.objects.filter(particular_id=user.id)
     context = {"events": events}
     event = get_object_or_404(Event, id=event_id)
+    if request.user != event.particular.user:
+        return HttpResponseForbidden(FORBIDDEN_ACCESS_ERROR)
     if user.id == event.particular_id:
         event.booking_state = BookingState.CANCELLED
         event.save()
@@ -65,6 +67,8 @@ def book_cancel(request, event_id):
 def book_edit(request, event_id):
     context = {}
     event = get_object_or_404(Event, id=event_id)
+    if request.user != event.particular.user:
+        return HttpResponseForbidden(FORBIDDEN_ACCESS_ERROR)
     # Ya no necesitas obtener todos los menús y sus platos, solo los platos del menú seleccionado.
     selected_menu = event.menu
     plates = Plate.objects.filter(menu=selected_menu)


### PR DESCRIPTION
## Arreglar editar reserva #310 

### Descripción

Al editar reservas se podían editar las de otros usuarios cambiando la URL.


## Lista de Verificación

Por favor, marca las casillas que correspondan:

- [x] Se ha probado que la aplicación se levanta en local.
- [x] Se ha probado que los cambios se integran bien en la aplicación.
- [x] Se ha probado que los cambios corresponden con los solicitados en la tarea.
